### PR TITLE
Adding copyitem functions for csv and varlists

### DIFF
--- a/src/util_i_csvlists.nss
+++ b/src/util_i_csvlists.nss
@@ -31,6 +31,7 @@
 
 // 1.69 string manipulation functions
 #include "x3_inc_string"
+#include "util_i_math"
 
 // -----------------------------------------------------------------------------
 //                              Function Prototypes
@@ -91,7 +92,7 @@ string RemoveListItem(string sList, string sListItem);
 // ---< util_i_csvlists >---
 // Starting at nIndex, copies nRange list items from sSource to sTarget.  Returns
 // number of list items copied to target list.
-int CopyListItem(string sSource, string sTarget, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+string CopyListItem(string sSource, string sTarget, int nIndex, int nRange = 1, int bAddUnique = FALSE);
 
 // ---< MergeLists >---
 // ---< util_i_csvlists >---
@@ -268,25 +269,24 @@ string RemoveListItem(string sList, string sListItem)
     return DeleteListItem(sList, FindListItem(sList, sListItem));
 }
 
-int CopyListItem(string sSource, string sTarget, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+string CopyListItem(string sSource, string sTarget, int nIndex, int nRange = 1, int bAddUnique = FALSE)
 {
-    string sValue, sCheck;
-    int i, nCopied, nCount = CountList(sSource);
+    string sValue;
+    int i, nCount = CountList(sSource);
 
-    if (nIndex < 0 || nIndex > nCount || !nCount)
-        return FALSE;
+    if (nIndex < 0 || nIndex >= nCount || !nCount)
+        return "";
+
+    if (nRange > nCount - nIndex)
+        nRange = clamp(nRange, 1, nCount - nIndex);
 
     for (i = 0; i < nRange; i++)
     {
         sValue = GetListItem(sSource, nIndex + i);
-        sCheck = sTarget;
         sTarget = AddListItem(sTarget, sValue, bAddUnique);
-
-        if (sCheck != sTarget)
-            nCopied++;
     }
 
-    return nCopied;
+    return sTarget;
 }
 
 string MergeLists(string sList1, string sList2, int bAddUnique = FALSE)

--- a/src/util_i_csvlists.nss
+++ b/src/util_i_csvlists.nss
@@ -277,8 +277,7 @@ string CopyListItem(string sSource, string sTarget, int nIndex, int nRange = 1, 
     if (nIndex < 0 || nIndex >= nCount || !nCount)
         return "";
 
-    if (nRange > nCount - nIndex)
-        nRange = clamp(nRange, 1, nCount - nIndex);
+    nRange = clamp(nRange, 1, nCount - nIndex);
 
     for (i = 0; i < nRange; i++)
     {

--- a/src/util_i_csvlists.nss
+++ b/src/util_i_csvlists.nss
@@ -48,13 +48,18 @@ int GetSubStringCount(string sString, string sSubString);
 // Trims all leading and trailing whitespace from sString.
 string TrimString(string sString);
 
-
 // ----- CSV Lists -------------------------------------------------------------
 
 // ---< CountList >---
 // ---< util_i_csvlists >---
 // Returns the number of items in the CSV list sList.
 int CountList(string sList);
+
+// ---< AddListItem >---
+// ---< util_i_csvlists >---
+// Returns the CSV list sList with sListItem added. If bAddUnique is TRUE, will
+// only add items to the list if they are not already there.
+string AddListItem(string sList, string sListItem, int bAddUnique = FALSE);
 
 // ---< GetListItem >---
 // ---< util_i_csvlists >---
@@ -82,11 +87,11 @@ string DeleteListItem(string sList, int nNth = 0);
 // Returns the CSV list sList with the first occurrence of sListItem removed.
 string RemoveListItem(string sList, string sListItem);
 
-// ---< AddListItem >---
+// ---< CopyListItem >---
 // ---< util_i_csvlists >---
-// Returns the CSV list sList with sListItem added. If bAddUnique is TRUE, will
-// only add items to the list if they are not already there.
-string AddListItem(string sList, string sListItem, int bAddUnique = FALSE);
+// Starting at nIndex, copies nRange list items from sSource to sTarget.  Returns
+// number of list items copied to target list.
+int CopyListItem(string sSource, string sTarget, int nIndex, int bAddUnique = FALSE, int nRange = 1);
 
 // ---< MergeLists >---
 // ---< util_i_csvlists >---
@@ -154,7 +159,6 @@ string TrimString(string sString)
 
     return sString;
 }
-
 
 // ----- CSV Lists -------------------------------------------------------------
 
@@ -262,6 +266,27 @@ string DeleteListItem(string sList, int nNth = 0)
 string RemoveListItem(string sList, string sListItem)
 {
     return DeleteListItem(sList, FindListItem(sList, sListItem));
+}
+
+int CopyListItem(string sSource, string sTarget, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+{
+    string sValue, sCheck;
+    int i, nCopied, nCount = CountList(sSource);
+
+    if (nIndex < 0 || nIndex > nCount || !nCount)
+        return FALSE;
+
+    for (i = 0; i < nRange; i++)
+    {
+        sValue = GetListItem(sSource, nIndex + i);
+        sCheck = sTarget;
+        sTarget = AddListItem(sTarget, sValue, bAddUnique);
+
+        if (sCheck != sTarget)
+            nCopied++;
+    }
+
+    return nCopied;
 }
 
 string MergeLists(string sList1, string sList2, int bAddUnique = FALSE)

--- a/src/util_i_csvlists.nss
+++ b/src/util_i_csvlists.nss
@@ -275,7 +275,7 @@ string CopyListItem(string sSource, string sTarget, int nIndex, int nRange = 1, 
     int i, nCount = CountList(sSource);
 
     if (nIndex < 0 || nIndex >= nCount || !nCount)
-        return "";
+        return sSource;
 
     nRange = clamp(nRange, 1, nCount - nIndex);
 

--- a/src/util_i_varlists.nss
+++ b/src/util_i_varlists.nss
@@ -1139,8 +1139,7 @@ int CopyListInt(object oSource, object oTarget, string sSourceName, string sTarg
     if (nIndex < 0 || nIndex >= nCount || !nCount)
         return FALSE;
 
-    if (nRange > nCount - nIndex)
-        nRange = clamp(nRange, 1, nCount - nIndex);
+    nRange = clamp(nRange, 1, nCount - nIndex);
 
     for (i = 0; i < nRange; i++)
     {
@@ -1160,8 +1159,7 @@ int CopyListLocation(object oSource, object oTarget, string sSourceName, string 
     if (nIndex < 0 || nIndex >= nCount || !nCount)
         return FALSE;
 
-    if (nRange > nCount - nIndex)
-        nRange = clamp(nRange, 1, nCount - nIndex);
+    nRange = clamp(nRange, 1, nCount - nIndex);
 
     for (i = 0; i < nRange; i++)
     {
@@ -1181,6 +1179,8 @@ int CopyListVector(object oSource, object oTarget, string sSourceName, string sT
     if (nIndex < 0 || nIndex >= nCount || !nCount)
         return FALSE;
 
+    nRange = clamp(nRange, 1, nCount - nIndex);
+
     for (i = 0; i < nRange; i++)
     {
         vValue = GetListVector(oSource, nIndex + i, sSourceName);
@@ -1199,6 +1199,8 @@ int CopyListObject(object oSource, object oTarget, string sSourceName, string sT
     if (nIndex < 0 || nIndex >= nCount || !nCount)
         return FALSE;
 
+    nRange = clamp(nRange, 1, nCount - nIndex);
+
     for (i = 0; i < nRange; i++)
     {
         oValue = GetListObject(oSource, nIndex + i, sSourceName);
@@ -1216,6 +1218,8 @@ int CopyListString(object oSource, object oTarget, string sSourceName, string sT
 
     if (nIndex < 0 || nIndex >= nCount || !nCount)
         return FALSE;
+
+    nRange = clamp(nRange, 1, nCount - nIndex);
 
     for (i = 0; i < nRange; i++)
     {

--- a/src/util_i_varlists.nss
+++ b/src/util_i_varlists.nss
@@ -85,6 +85,12 @@ int AddListObject(object oTarget, object oValue, string sListName = "", int bAdd
 // Returns whether the addition was successful.
 int AddListString(object oTarget, string sValue, string sListName = "", int bAddUnique = FALSE);
 
+// ---< GetListFloat >---
+// ---< util_i_varlists >---
+// Returns the float at nIndex in oTarget's float list sListName. If no float is
+// found at that index, 0.0 is returned.
+float GetListFloat(object oTarget, int nIndex = 0, string sListName = "");
+
 // ---< GetListInt >---
 // ---< util_i_varlists >---
 // Returns the int at nIndex in oTarget's int list sListName. If no int is found
@@ -343,11 +349,47 @@ void SetListObject(object oTarget, int nIndex, object oValue, string sListName =
 // of the list, nothing is added.
 void SetListString(object oTarget, int nIndex, string sValue, string sListName = "");
 
-// ---< GetListFloat >---
+// ---< CopyListFloat >---
 // ---< util_i_varlists >---
-// Returns the float at nIndex in oTarget's float list sListName. If no float is
-// found at that index, 0.0 is returned.
-float GetListFloat(object oTarget, int nIndex = 0, string sListName = "");
+// Starting at nIndex, copies nRange items from float list sSourceName on oSource
+// and adds them to list sTargetName on oTarget.  Returns the number of list items
+// copied to the target list.
+int CopyListFloat(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+
+// ---< CopyListInt >---
+// ---< util_i_varlists >---
+// Starting at nIndex, copies nRange items from int list sSourceName on oSource
+// and adds them to list sTargetName on oTarget.  Returns the number of list items
+// copied to the target list.
+int CopyListInt(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+
+// ---< CopyListLocation >---
+// ---< util_i_varlists >---
+// Starting at nIndex, copies nRange items from location list sSourceName on oSource
+// and adds them to list sTargetName on oTarget.  Returns the number of list items
+// copied to the target list.
+int CopyListLocation(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+
+// ---< CopyListVector >---
+// ---< util_i_varlists >---
+// Starting at nIndex, copies nRange items from vector list sSourceName on oSource
+// and adds them to list sTargetName on oTarget.  Returns the number of list items
+// copied to the target list.
+int CopyListVector(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+
+// ---< CopyListObject >---
+// ---< util_i_varlists >---
+// Starting at nIndex, copies nRange items from object list sSourceName on oSource
+// and adds them to list sTargetName on oTarget.  Returns the number of list items
+// copied to the target list.
+int CopyListObject(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+
+// ---< CopyListString >---
+// ---< util_i_varlists >---
+// Starting at nIndex, copies nRange items from string list sSourceName on oSource
+// and adds them to list sTargetName on oTarget.  Returns the number of list items
+// copied to the target list.
+int CopyListString(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
 
 // ---< DeleteFloatList >---
 // ---< util_i_varlists >---
@@ -1064,6 +1106,114 @@ void SetListString(object oTarget, int nIndex, string sValue, string sListName =
         AddListString(oTarget, sValue, sListName);
     else
         SetLocalString(oTarget, LIST_REF + sListName + IntToString(nIndex), sValue);
+}
+
+int CopyListFloat(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+{
+    float fValue;
+    int  i, nCopied, nCount = CountFloatList(oSource, sSourceName);
+
+    if (nIndex < 0 || nIndex > nCount || !nCount)
+        return FALSE;
+
+    for (i = 0; i < nRange; i++)
+    {
+        fValue = GetListFloat(oSource, nIndex + i, sSourceName);
+        if (AddListFloat(oTarget, fValue, sTargetName, bAddUnique))
+            nCopied++;
+    }
+
+    return nCopied;
+}
+
+int CopyListInt(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+{
+    int nValue;
+    int  i, nCopied, nCount = CountIntList(oSource, sSourceName);
+
+    if (nIndex < 0 || nIndex > nCount || !nCount)
+        return FALSE;
+
+    for (i = 0; i < nRange; i++)
+    {
+        nValue = GetListInt(oSource, nIndex + i, sSourceName);
+        if (AddListInt(oTarget, nValue, sTargetName, bAddUnique))
+            nCopied++;
+    }
+
+    return nCopied;
+}
+
+int CopyListLocation(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+{
+    location lValue;
+    int  i, nCopied, nCount = CountLocationList(oSource, sSourceName);
+
+    if (nIndex < 0 || nIndex > nCount || !nCount)
+        return FALSE;
+
+    for (i = 0; i < nRange; i++)
+    {
+        lValue = GetListLocation(oSource, nIndex + i, sSourceName);
+        if (AddListLocation(oTarget, lValue, sTargetName, bAddUnique))
+            nCopied++;
+    }
+
+    return nCopied;
+}
+
+int CopyListVector(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+{
+    vector vValue;
+    int  i, nCopied, nCount = CountVectorList(oSource, sSourceName);
+
+    if (nIndex < 0 || nIndex > nCount || !nCount)
+        return FALSE;
+
+    for (i = 0; i < nRange; i++)
+    {
+        vValue = GetListVector(oSource, nIndex + i, sSourceName);
+        if (AddListVector(oTarget, vValue, sTargetName, bAddUnique))
+            nCopied++;
+    }
+
+    return nCopied;
+}
+
+int CopyListObject(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+{
+    object oValue;
+    int  i, nCopied, nCount = CountObjectList(oSource, sSourceName);
+
+    if (nIndex < 0 || nIndex > nCount || !nCount)
+        return FALSE;
+
+    for (i = 0; i < nRange; i++)
+    {
+        oValue = GetListObject(oSource, nIndex + i, sSourceName);
+        if (AddListObject(oTarget, oValue, sTargetName, bAddUnique))
+            nCopied++;
+    }
+
+    return nCopied;
+}
+
+int CopyListString(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+{
+    string sValue;
+    int  i, nCopied, nCount = CountStringList(oSource, sSourceName);
+
+    if (nIndex < 0 || nIndex > nCount || !nCount)
+        return FALSE;
+
+    for (i = 0; i < nRange; i++)
+    {
+        sValue = GetListString(oSource, nIndex + i, sSourceName);
+        if (AddListString(oTarget, sValue, sTargetName, bAddUnique))
+            nCopied++;
+    }
+
+    return nCopied;
 }
 
 void DeleteFloatList(object oTarget, string sListName = "")

--- a/src/util_i_varlists.nss
+++ b/src/util_i_varlists.nss
@@ -25,6 +25,8 @@
 // Acknowledgements: these functions are adapted from those in Memetic AI.
 // -----------------------------------------------------------------------------
 
+#include "util_i_math"
+
 // -----------------------------------------------------------------------------
 //                                   Constants
 // -----------------------------------------------------------------------------
@@ -354,42 +356,42 @@ void SetListString(object oTarget, int nIndex, string sValue, string sListName =
 // Starting at nIndex, copies nRange items from float list sSourceName on oSource
 // and adds them to list sTargetName on oTarget.  Returns the number of list items
 // copied to the target list.
-int CopyListFloat(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+int CopyListFloat(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE);
 
 // ---< CopyListInt >---
 // ---< util_i_varlists >---
 // Starting at nIndex, copies nRange items from int list sSourceName on oSource
 // and adds them to list sTargetName on oTarget.  Returns the number of list items
 // copied to the target list.
-int CopyListInt(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+int CopyListInt(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE);
 
 // ---< CopyListLocation >---
 // ---< util_i_varlists >---
 // Starting at nIndex, copies nRange items from location list sSourceName on oSource
 // and adds them to list sTargetName on oTarget.  Returns the number of list items
 // copied to the target list.
-int CopyListLocation(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+int CopyListLocation(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE);
 
 // ---< CopyListVector >---
 // ---< util_i_varlists >---
 // Starting at nIndex, copies nRange items from vector list sSourceName on oSource
 // and adds them to list sTargetName on oTarget.  Returns the number of list items
 // copied to the target list.
-int CopyListVector(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+int CopyListVector(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE);
 
 // ---< CopyListObject >---
 // ---< util_i_varlists >---
 // Starting at nIndex, copies nRange items from object list sSourceName on oSource
 // and adds them to list sTargetName on oTarget.  Returns the number of list items
 // copied to the target list.
-int CopyListObject(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+int CopyListObject(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE);
 
 // ---< CopyListString >---
 // ---< util_i_varlists >---
 // Starting at nIndex, copies nRange items from string list sSourceName on oSource
 // and adds them to list sTargetName on oTarget.  Returns the number of list items
 // copied to the target list.
-int CopyListString(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1);
+int CopyListString(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE);
 
 // ---< DeleteFloatList >---
 // ---< util_i_varlists >---
@@ -1108,13 +1110,16 @@ void SetListString(object oTarget, int nIndex, string sValue, string sListName =
         SetLocalString(oTarget, LIST_REF + sListName + IntToString(nIndex), sValue);
 }
 
-int CopyListFloat(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+int CopyListFloat(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE)
 {
     float fValue;
     int  i, nCopied, nCount = CountFloatList(oSource, sSourceName);
 
-    if (nIndex < 0 || nIndex > nCount || !nCount)
+    if (nIndex < 0 || nIndex >= nCount || !nCount)
         return FALSE;
+
+    if (nRange > nCount - nIndex)
+        nRange = clamp(nRange, 1, nCount - nIndex);
 
     for (i = 0; i < nRange; i++)
     {
@@ -1126,13 +1131,16 @@ int CopyListFloat(object oSource, object oTarget, string sSourceName, string sTa
     return nCopied;
 }
 
-int CopyListInt(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+int CopyListInt(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE)
 {
     int nValue;
     int  i, nCopied, nCount = CountIntList(oSource, sSourceName);
 
-    if (nIndex < 0 || nIndex > nCount || !nCount)
+    if (nIndex < 0 || nIndex >= nCount || !nCount)
         return FALSE;
+
+    if (nRange > nCount - nIndex)
+        nRange = clamp(nRange, 1, nCount - nIndex);
 
     for (i = 0; i < nRange; i++)
     {
@@ -1144,13 +1152,16 @@ int CopyListInt(object oSource, object oTarget, string sSourceName, string sTarg
     return nCopied;
 }
 
-int CopyListLocation(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+int CopyListLocation(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE)
 {
     location lValue;
     int  i, nCopied, nCount = CountLocationList(oSource, sSourceName);
 
-    if (nIndex < 0 || nIndex > nCount || !nCount)
+    if (nIndex < 0 || nIndex >= nCount || !nCount)
         return FALSE;
+
+    if (nRange > nCount - nIndex)
+        nRange = clamp(nRange, 1, nCount - nIndex);
 
     for (i = 0; i < nRange; i++)
     {
@@ -1162,12 +1173,12 @@ int CopyListLocation(object oSource, object oTarget, string sSourceName, string 
     return nCopied;
 }
 
-int CopyListVector(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+int CopyListVector(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE)
 {
     vector vValue;
     int  i, nCopied, nCount = CountVectorList(oSource, sSourceName);
 
-    if (nIndex < 0 || nIndex > nCount || !nCount)
+    if (nIndex < 0 || nIndex >= nCount || !nCount)
         return FALSE;
 
     for (i = 0; i < nRange; i++)
@@ -1180,12 +1191,12 @@ int CopyListVector(object oSource, object oTarget, string sSourceName, string sT
     return nCopied;
 }
 
-int CopyListObject(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+int CopyListObject(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE)
 {
     object oValue;
     int  i, nCopied, nCount = CountObjectList(oSource, sSourceName);
 
-    if (nIndex < 0 || nIndex > nCount || !nCount)
+    if (nIndex < 0 || nIndex >= nCount || !nCount)
         return FALSE;
 
     for (i = 0; i < nRange; i++)
@@ -1198,12 +1209,12 @@ int CopyListObject(object oSource, object oTarget, string sSourceName, string sT
     return nCopied;
 }
 
-int CopyListString(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int bAddUnique = FALSE, int nRange = 1)
+int CopyListString(object oSource, object oTarget, string sSourceName, string sTargetName, int nIndex, int nRange = 1, int bAddUnique = FALSE)
 {
     string sValue;
     int  i, nCopied, nCount = CountStringList(oSource, sSourceName);
 
-    if (nIndex < 0 || nIndex > nCount || !nCount)
+    if (nIndex < 0 || nIndex >= nCount || !nCount)
         return FALSE;
 
     for (i = 0; i < nRange; i++)


### PR DESCRIPTION
Added copyitem functions for csv and varlists.  Although defaulted to a single item, these functions can copy a continugous range of items and will return the number of items copied as an error check against adding unique items that may already exist on the target list (bUnique = TRUE).  If !bUnique, the returned count should equal the range passed.

Moved a couple of function prototypes because they ended up in strange locations.