### PR TITLE
adds `LoadPrefixLibraries` to `util_i_libraries`

### DIFF
--- a/src/util_i_libraries.nss
+++ b/src/util_i_libraries.nss
@@ -80,6 +80,14 @@ void LoadLibrary(string sLibrary, int bForce = FALSE);
 // unless bForce is TRUE.
 void LoadLibraries(string sLibraries, int bForce = FALSE);
 
+// ---< LoadPrefixLibraries >---
+// ---< util_i_libraries >---
+// Loads all libraries included script files prefixed with sPrefix.  The scripts
+// inside the library are registered and are accessible via a call to
+// RunLibraryScript().  If any of the libraries have already been loaded, this
+// will not reload them unless bForce is TRUE.
+void LoadPrefixLibraries(string sPrefix, int bForce = FALSE);
+
 // ---< RunLibraryScript >---
 // ---< util_i_libraries >---
 // Runs sScript, dispatching into a library if the script is registered as a
@@ -228,6 +236,25 @@ void LoadLibraries(string sLibraries, int bForce = FALSE)
     int i, nCount = CountList(sLibraries);
     for (i = 0; i < nCount; i++)
         LoadLibrary(GetListItem(sLibraries, i), bForce);
+}
+
+void LoadPrefixLibraries(string sPrefix, int bForce = FALSE)
+{
+    if (sPrefix == "")
+        return;
+    else 
+        sPrefix += "_l_";
+
+    Debug("Attempting to " + (bForce ? "force " : "") + "load libraries " +
+        "prefixed with " + sPrefix);
+
+    int i = 1;
+    string sLibrary = ResManFindPrefix(sPrefix, RESTYPE_NCS, i++);
+    while (sLibrary != "")
+    {
+        LoadLibrary(sLibrary, bForce);
+        sLibrary = ResManFindPrefix(sPrefix, RESTYPE_NCS, i++);
+    }
 }
 
 int RunLibraryScript(string sScript, object oSelf = OBJECT_SELF)

--- a/src/util_i_libraries.nss
+++ b/src/util_i_libraries.nss
@@ -82,7 +82,7 @@ void LoadLibraries(string sLibraries, int bForce = FALSE);
 
 // ---< LoadPrefixLibraries >---
 // ---< util_i_libraries >---
-// Loads all libraries included script files prefixed with sPrefix.  The scripts
+// Loads all libraries included in script files prefixed with sPrefix.  The scripts
 // inside the library are registered and are accessible via a call to
 // RunLibraryScript().  If any of the libraries have already been loaded, this
 // will not reload them unless bForce is TRUE.

--- a/src/util_i_libraries.nss
+++ b/src/util_i_libraries.nss
@@ -19,11 +19,11 @@
 //                                   Constants
 // -----------------------------------------------------------------------------
 
-const string LIB_RETURN       = "LIB_RETURN";
+const string LIB_RETURN  = "LIB_RETURN";
 const string LIB_ENTRY   = "LIB_ENTRY";
 const string LIB_LIBRARY = "LIB_LIBRARY";
 const string LIB_SCRIPT  = "LIB_SCRIPT";
-const string LIB_INIT         = "LIB_INIT";
+const string LIB_INIT    = "LIB_INIT";
 
 // -----------------------------------------------------------------------------
 //                              Function Prototypes
@@ -242,8 +242,6 @@ void LoadPrefixLibraries(string sPrefix, int bForce = FALSE)
 {
     if (sPrefix == "")
         return;
-    else 
-        sPrefix += "_l_";
 
     Debug("Attempting to " + (bForce ? "force " : "") + "load libraries " +
         "prefixed with " + sPrefix);


### PR DESCRIPTION
See note from discord discussion.  This is simply a convenience function to allow auto-loading sub-libraries for a plugin without having to specify each file name.  Instead the user can specify a prefix, such as `xxx` and all ncs files that start with `xxx_l_` will load.  The purpose of this is to give the user a little more control over the order specific libraries are loaded in, and to prevent having to specific each library file, allowing users to add/remove libraries from a plugin without having to change the plugin code.