### PR TITLE
added event hook functionality to util_i_debug

### DIFF
--- a/src/util_c_debug.nss
+++ b/src/util_c_debug.nss
@@ -1,68 +1,76 @@
-// -----------------------------------------------------------------------------
-//    File: util_c_debug.nss
-//  System: Utilities (configuration script)
-//     URL: https://github.com/squattingmonk/sm-utils
-// Authors: Michael A. Sinclair (Squatting Monk) <squattingmonk@gmail.com>
-// -----------------------------------------------------------------------------
-// This file holds utility functions for generating debug messages.
-// -----------------------------------------------------------------------------
-// This file contains functions and constants called by util_i_debug.nss.  The
-// functions in this file are meant to be customized by the user, if desired,
-// to achieve specific, custom debugging functionality.
-// -----------------------------------------------------------------------------
+/// ----------------------------------------------------------------------------
+/// @file   util_c_debug.nss
+/// @author Ed Burke (tinygiant98) <af.hog.pilot@gmail.com>
+/// @author Michael A. Sinclair (Squatting Monk) <squattingmonk@gmail.com>
+/// @brief  Configuration file for util_i_debug.nss.
+/// ----------------------------------------------------------------------------
 
 // -----------------------------------------------------------------------------
-//                                   Constants
+//                        Helper Constants and Functions
+// -----------------------------------------------------------------------------
+// If you need custom constants, functions, or #includes, you may add them here.
+// Since this file is included by util_i_debug.nss, you do not need to #include
+// it to use its constants.
 // -----------------------------------------------------------------------------
 
-/// @brief this constant defines the debug level at which a user-defined
-///     event will be triggered.  This is the minimum debug level to trigger
-///     the event.  For example, setting this constant to DEBUG_LEVEL_ERROR
-///     means the user-defined event will be triggered only for debug statements
-///     marked as DEBUG_LEVEL_ERROR and DEBUG_LEVEL_CRITICAL.  If set to 
+/*
+// These constants are used by the example code below. Uncomment if you want to
+// use them.
+
+/// @brief This is the minimum debug level required to trigger custom handling.
+/// @details Setting this to DEBUG_LEVEL_ERROR means OnDebug() will handle only
+///     messages marked as DEBUG_LEVEL_ERROR and DEBUG_LEVEL_CRITICAL. If set to
 ///     DEBUG_LEVEL_NONE, the user-defined event will never be triggered.
 /// @warning It is not recommended to set this level to DEBUG_LEVEL_NOTICE or
 ///     DEBUG_LEVEL_DEBUG as this could create high message traffic rates.
-const int DEBUG_LEVEL_EVENT_TRIGGER = DEBUG_LEVEL_ERROR;
+const int DEBUG_EVENT_TRIGGER_LEVEL = DEBUG_LEVEL_ERROR;
 
-// Script parameter definition -- do not modify
-
+// These are varnames for script parameters
 const string DEBUG_PARAM_PREFIX  = "DEBUG_PARAM_PREFIX";
 const string DEBUG_PARAM_MESSAGE = "DEBUG_PARAM_MESSAGE";
 const string DEBUG_PARAM_LEVEL   = "DEBUG_PARAM_LEVEL";
 const string DEBUG_PARAM_TARGET  = "DEBUG_PARAM_TARGET";
+*/
 
 // -----------------------------------------------------------------------------
-//                              Function Definitions
+//                                 Debug Handler
+// -----------------------------------------------------------------------------
+// You may alter the contents of this function, but do not alters its signature.
 // -----------------------------------------------------------------------------
 
-/// @brief Called from Debug() in util_i_debug.nss when a debug event qualified
-///     by the value of DEBUG_LEVEL_EVENT_TRIGGER is detected.  This function
-///     provides a user-definable hook into the debug notification system.
-/// @param sPrefix the debug message source as created by GetDebugPrefix()
-/// @param sMessage the debug message as provided to Debug()
-/// @param nLevel the debug level of the message as provided to Debug(); will 
-///     always be less than or equal to DEBUG_LEVEL_EVENT_TRIGGER and should
-///     never be 0.
-/// @param oTarget the game object the debug statement was sourced from as
-///     provided to Debug()
-/// @returns TRUE or FALSE, used by Debug() to determine if the normal messaging
-///     (logs, DMs, etc.) is accomplished.
-int PublishDebugEvent(string sPrefix, string sMessage, int nLevel, object oTarget)
+/// @brief Custom debug event handler
+/// @details This is a customizable function that runs before a message is shown
+///     using Debug(). This function provides a user-definable hook into the
+///     debug notification system. For example, a module can use this hook to
+///     execute a script that may be able to handle module-specific error
+///     handling or messaging.
+/// @param sPrefix the debug message source provided by GetDebugPrefix()
+/// @param sMessage the debug message provided to Debug()
+/// @param nLevel the debug level of the message provided to Debug()
+/// @param oTarget the game object being debugged as provided to Debug()
+/// @returns TRUE if the message should be sent as normal; FALSE if no message
+///     should be sent.
+/// @note This function will never fire if oTarget is not debugging messages of
+///     nLevel.
+/// @warning Do not call Debug() or its aliases Notice(), Warning(), Error(), or
+///     CriticalError() from this function; that would cause an infinite loop.
+int HandleDebug(string sPrefix, string sMessage, int nLevel, object oTarget)
 {
-    // This function allows a user-definable hook into the debug messaging
-    //  system.  For example, a module can use this hook to execute any
-    //  script that may be able to handle module-specific error handling or
-    //  messaging.  The following example code allows an external script to
-    //  handle the event with access to the appropriate script parameters.
-    //  Optionally, all event handling can be accomplished directly in this
-    //  function.
     /*
-    SetScriptParam(DEBUG_PARAM_PREFIX, sPrefix);
+    // The following example code allows an external script to handle the event
+    // with access to the appropriate script parameters. Optionally, all event
+    // handling can be accomplished directly in this function.
+
+    // Only do custom handling if the debug level is error or critical error.
+    if (!nLevel || nLevel > DEBUG_EVENT_TRIGGER_LEVEL)
+        return TRUE;
+
+    SetScriptParam(DEBUG_PARAM_PREFIX,  sPrefix);
     SetScriptParam(DEBUG_PARAM_MESSAGE, sMessage);
-    SetScriptParam(DEBUG_PARAM_LEVEL, IntToString(nLevel));
-    SetScriptParam(DEBUG_PARAM_TARGET, ObjectToString(oTarget));
+    SetScriptParam(DEBUG_PARAM_LEVEL,   IntToString(nLevel));
+    SetScriptParam(DEBUG_PARAM_TARGET,  ObjectToString(oTarget));
     ExecuteScript("mydebugscript", oTarget);
+    return FALSE;
     */
 
     return TRUE;

--- a/src/util_c_debug.nss
+++ b/src/util_c_debug.nss
@@ -1,0 +1,69 @@
+// -----------------------------------------------------------------------------
+//    File: util_c_debug.nss
+//  System: Utilities (configuration script)
+//     URL: https://github.com/squattingmonk/sm-utils
+// Authors: Michael A. Sinclair (Squatting Monk) <squattingmonk@gmail.com>
+// -----------------------------------------------------------------------------
+// This file holds utility functions for generating debug messages.
+// -----------------------------------------------------------------------------
+// This file contains functions and constants called by util_i_debug.nss.  The
+// functions in this file are meant to be customized by the user, if desired,
+// to achieve specific, custom debugging functionality.
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+//                                   Constants
+// -----------------------------------------------------------------------------
+
+/// @brief this constant defines the debug level at which a user-defined
+///     event will be triggered.  This is the minimum debug level to trigger
+///     the event.  For example, setting this constant to DEBUG_LEVEL_ERROR
+///     means the user-defined event will be triggered only for debug statements
+///     marked as DEBUG_LEVEL_ERROR and DEBUG_LEVEL_CRITICAL.  If set to 
+///     DEBUG_LEVEL_NONE, the user-defined event will never be triggered.
+/// @warning It is not recommended to set this level to DEBUG_LEVEL_NOTICE or
+///     DEBUG_LEVEL_DEBUG as this could create high message traffic rates.
+const int DEBUG_LEVEL_EVENT_TRIGGER = DEBUG_LEVEL_ERROR;
+
+// Script parameter definition -- do not modify
+
+const string DEBUG_PARAM_PREFIX  = "DEBUG_PARAM_PREFIX";
+const string DEBUG_PARAM_MESSAGE = "DEBUG_PARAM_MESSAGE";
+const string DEBUG_PARAM_LEVEL   = "DEBUG_PARAM_LEVEL";
+const string DEBUG_PARAM_TARGET  = "DEBUG_PARAM_TARGET";
+
+// -----------------------------------------------------------------------------
+//                              Function Definitions
+// -----------------------------------------------------------------------------
+
+/// @brief Called from Debug() in util_i_debug.nss when a debug event qualified
+///     by the value of DEBUG_LEVEL_EVENT_TRIGGER is detected.  This function
+///     provides a user-definable hook into the debug notification system.
+/// @param sPrefix the debug message source as created by GetDebugPrefix()
+/// @param sMessage the debug message as provided to Debug()
+/// @param nLevel the debug level of the message as provided to Debug(); will 
+///     always be less than or equal to DEBUG_LEVEL_EVENT_TRIGGER and should
+///     never be 0.
+/// @param oTarget the game object the debug statement was sourced from as
+///     provided to Debug()
+/// @returns TRUE or FALSE, used by Debug() to determine if the normal messaging
+///     (logs, DMs, etc.) is accomplished.
+int PublishDebugEvent(string sPrefix, string sMessage, int nLevel, object oTarget)
+{
+    // This function allows a user-definable hook into the debug messaging
+    //  system.  For example, a module can use this hook to execute any
+    //  script that may be able to handle module-specific error handling or
+    //  messaging.  The following example code allows an external script to
+    //  handle the event with access to the appropriate script parameters.
+    //  Optionally, all event handling can be accomplished directly in this
+    //  function.
+    /*
+    SetScriptParam(DEBUG_PARAM_PREFIX, sPrefix);
+    SetScriptParam(DEBUG_PARAM_MESSAGE, sMessage);
+    SetScriptParam(DEBUG_PARAM_LEVEL, IntToString(nLevel));
+    SetScriptParam(DEBUG_PARAM_TARGET, ObjectToString(oTarget));
+    ExecuteScript("mydebugscript", oTarget);
+    */
+
+    return TRUE;
+}

--- a/src/util_i_debug.nss
+++ b/src/util_i_debug.nss
@@ -7,8 +7,6 @@
 // This file holds utility functions for generating debug messages.
 // -----------------------------------------------------------------------------
 
-#include "util_i_color"
-
 // -----------------------------------------------------------------------------
 //                                   Constants
 // -----------------------------------------------------------------------------
@@ -33,6 +31,9 @@ const int DEBUG_LOG_FILE = 0x1;
 const int DEBUG_LOG_DM   = 0x2;
 const int DEBUG_LOG_PC   = 0x4;
 const int DEBUG_LOG_ALL  = 0xf;
+
+#include "util_i_color"
+#include "util_c_debug"
 
 // -----------------------------------------------------------------------------
 //                              Function Prototypes
@@ -255,6 +256,12 @@ void Debug(string sMessage, int nLevel = DEBUG_LEVEL_DEBUG, object oTarget = OBJ
             case DEBUG_LEVEL_WARNING:  sPrefix += "[Warning] ";        break;
         }
 
+        if (nLevel > DEBUG_LEVEL_NONE && nLevel <= DEBUG_LEVEL_EVENT_TRIGGER)
+        {
+            if (!PublishDebugEvent(sPrefix, UnColorString(sMessage), nLevel, oTarget))
+                return;
+        }
+        
         sMessage = sPrefix + sMessage;
         int nLogging = GetLocalInt(GetModule(), DEBUG_LOG);
 

--- a/src/util_i_debug.nss
+++ b/src/util_i_debug.nss
@@ -256,12 +256,9 @@ void Debug(string sMessage, int nLevel = DEBUG_LEVEL_DEBUG, object oTarget = OBJ
             case DEBUG_LEVEL_WARNING:  sPrefix += "[Warning] ";        break;
         }
 
-        if (nLevel > DEBUG_LEVEL_NONE && nLevel <= DEBUG_LEVEL_EVENT_TRIGGER)
-        {
-            if (!PublishDebugEvent(sPrefix, UnColorString(sMessage), nLevel, oTarget))
-                return;
-        }
-        
+        if (!HandleDebug(sPrefix, sMessage, nLevel, oTarget))
+            return;
+
         sMessage = sPrefix + sMessage;
         int nLogging = GetLocalInt(GetModule(), DEBUG_LOG);
 


### PR DESCRIPTION
Added `util_c_debug` to allow a user-defined event hook for user-specified debug levels.  Moved the include location in `util_i_debug` to allow `util_c_debug` access to the debug level constants.