### PR TITLE
modify UnColorString to use RegExpReplace

### DIFF
--- a/src/util_i_color.nss
+++ b/src/util_i_color.nss
@@ -344,21 +344,5 @@ string HSVColorString(string sString, struct HSV hsv)
 
 string UnColorString(string sString)
 {
-    sString = StringReplace(sString, "</c>", "");
-    int nOpen = FindSubString(sString, "<c");
-    int nClose = FindSubString(sString, ">", nOpen);
-    int nLength;
-    string sPrefix, sSuffix;
-
-    while (nOpen != -1 && nClose != -1)
-    {
-        nLength = GetStringLength(sString);
-        sPrefix = GetStringLeft(sString, nOpen);
-        sSuffix = GetStringRight(sString, nLength - nClose - 1);
-        sString = sPrefix + sSuffix;
-        nOpen = FindSubString(sString, "<c");
-        nClose = FindSubString(sString, ">", nOpen);
-    }
-
-    return sString;
+    return RegExpReplace("<c.{3}>|<\\/c>", sString, "");
 }


### PR DESCRIPTION
Came up with this earlier today and it seems to work to replace all instances of `<c???>` and `</c>` with `""`.

Requires .35.