### PR TITLE
allow multiple substitutions of the same token

### DIFF
--- a/src/util_i_strings.nss
+++ b/src/util_i_strings.nss
@@ -410,7 +410,7 @@ string SubstituteString(string s, json jArray, string sDesignator = "$")
         else if (nType == JSON_TYPE_BOOL)    sValue = JsonGetInt(jValue) == 1 ? "true" : "false";
         else continue;
 
-        s = SubstituteSubString(s, sDesignator + IntToString(n + 1), sValue);
+        s = SubstituteSubStrings(s, sDesignator + IntToString(n + 1), sValue);
     }
 
     return s;


### PR DESCRIPTION
Added a single character which will still accomplish the original intent, but also allow multiple substitutions of the same token (i.e. multiple `$1` in a single string).