### PR TITLE
fix!: make GetStringSlice indexes inclusive

### DIFF
--- a/src/util_i_csvlists.nss
+++ b/src/util_i_csvlists.nss
@@ -182,7 +182,7 @@ string GetListItem(string sList, int nIndex = 0)
         return "";
 
     // Get the element
-    return TrimString(GetStringSlice(sList, nLeft, nRight));
+    return TrimString(GetStringSlice(sList, nLeft, nRight - 1));
 }
 
 int FindListItem(string sList, string sListItem)
@@ -196,7 +196,7 @@ int FindListItem(string sList, string sListItem)
     do
     {
         nEnd = FindSubString(sList, ",", nStart);
-        if (TrimString(GetStringSlice(sList, nStart, nEnd)) == sListItem)
+        if (TrimString(GetStringSlice(sList, nStart, nEnd - 1)) == sListItem)
             return nItem;
         nItem++;
         nStart = nEnd + 1;
@@ -221,16 +221,18 @@ string DeleteListItem(string sList, int nIndex = 0)
         if (nIndex)
         {
             nPos = FindSubStringN(sList, ",", nIndex - 1);
-            return TrimStringRight(GetStringSlice(sList, 0, nPos));
+            return TrimStringRight(GetStringSlice(sList, 0, nPos - 1));
         }
 
         return "";
     }
 
     string sRight = GetStringSlice(sList, nPos + 1);
+    if (!nIndex)
+        return sRight;
     nPos = FindSubStringN(sList, ",", nIndex - 1);
     sRight = nPos < 0 ? TrimStringLeft(sRight) : sRight;
-    return GetStringSlice(sList, 0, nPos + 1) + sRight;
+    return GetStringSlice(sList, 0, nPos) + sRight;
 }
 
 string RemoveListItem(string sList, string sListItem)
@@ -310,7 +312,7 @@ json ListToJson(string sList)
     do
     {
         nEnd = FindSubString(sList, ",", nStart);
-        sItem = TrimString(GetStringSlice(sList, nStart, nEnd));
+        sItem = TrimString(GetStringSlice(sList, nStart, nEnd - 1));
         jRet = JsonArrayInsert(jRet, JsonString(sItem));
         nStart = nEnd + 1;
     } while (nEnd != -1);

--- a/src/util_i_strftime.nss
+++ b/src/util_i_strftime.nss
@@ -841,8 +841,8 @@ string strftime(struct Time t, string sFormat, string sLocale)
         {
             case -1:
             {
-                string sError = GetStringSlice(sFormat, nOffset, nPos + 1);
-                string sColored = GetStringSlice(sFormat, 0, nOffset) +
+                string sError = GetStringSlice(sFormat, nOffset, nPos);
+                string sColored = GetStringSlice(sFormat, 0, nOffset - 1) +
                                   HexColorString(sError, COLOR_RED) +
                                   GetStringSlice(sFormat, nPos + 1);
                 Error("Illegal time format \"" + sError + "\": " + sColored);

--- a/src/util_i_strings.nss
+++ b/src/util_i_strings.nss
@@ -47,6 +47,8 @@ string GetChar(string sString, int nPos);
 ///     return to the end of the string.
 /// @returns "" if nStart is not at least nStart + 1 characters long or if nEnd
 ///     is < nStart and not -1.
+/// @note Both nStart and nEnd are inclusive, so if nStart == nEnd, the
+///     character at that index will be returned.
 string GetStringSlice(string sString, int nStart, int nEnd = -1);
 
 /// @brief Replace the substring bounded by a string slice with another string.
@@ -234,10 +236,10 @@ string GetStringSlice(string sString, int nStart, int nEnd = -1)
     if (nEnd < 0 || nEnd > nLength)
         nEnd = nLength;
 
-    if (nStart < 0 || nStart >= nLength || nStart >= nEnd)
+    if (nStart < 0 || nStart > nEnd)
         return "";
 
-    return GetSubString(sString, nStart, nEnd - nStart);
+    return GetSubString(sString, nStart, nEnd - nStart + 1);
 }
 
 string ReplaceSubString(string sString, string sSub, int nStart, int nEnd)


### PR DESCRIPTION
Previously, `GetStringSlice()` would have its start index be inclusive and its end index be exclusive. This meant `GetStringSlice("foo", 0, 1) == "f"`. This was inconsistent with `ReplaceSubString()`, not clearly documented, and caused some bugs where other functions expected different behavior. This changes `GetStringSlice()` so both nStart and nEnd are inclusive, meaning `GetStringSlice("foo", 0, 1) == "fo"`.

This is a BREAKING CHANGE if your code depended on this function.