### PR TITLE
Modify `SubstituteString` to traverse `jArray` in reverse order to pr…

### DIFF
--- a/src/util_i_strings.nss
+++ b/src/util_i_strings.nss
@@ -401,7 +401,7 @@ string SubstituteString(string s, json jArray, string sDesignator = "$")
     if (JsonGetType(jArray) != JSON_TYPE_ARRAY)
         return s;
 
-    int n; for (n; n < JsonGetLength(jArray); n++)
+    int n; for (n = JsonGetLength(jArray) - 1; n >= 0; n--)
     {
         string sValue;
         json jValue = JsonArrayGet(jArray, n);


### PR DESCRIPTION
…event string overwrites when `jArray` contains more than ten items.

When working on an automate-db creator tool, I found that any `jArray` with more than 10 items would substitute incorrectly because when attempt to find and replace `$1`, it would also replace `$10`, but leave the `0` in place, thus not finding `$10` when it's turn came around.  This change modifies the function to traverse `jArray` in reverse order to prevent this issue.