### PR TITLE
Handle white space after constant value

### DIFF
--- a/src/util_i_constants.nss
+++ b/src/util_i_constants.nss
@@ -203,7 +203,7 @@ string GetConstantName(string sPrefix, json jValue, int bSuffixOnly = FALSE, str
 
     sPrefix = GetStringUpperCase(bSuffixOnly ? sPrefix + "_?(" : "(" + sPrefix);
     json jMatch = RegExpMatch(sPrefix + ".*?)(?: |=).*?=\\s*(" +
-        JsonDump(jValue) + ");", ResManGetFileContents(sFile, RESTYPE_NSS));
+        JsonDump(jValue) + ")\\s*;", ResManGetFileContents(sFile, RESTYPE_NSS));
 
     return jMatch != JsonArray() ? JsonGetString(JsonArrayGet(jMatch, 1)) : "";
 }

--- a/src/util_i_math.nss
+++ b/src/util_i_math.nss
@@ -72,6 +72,17 @@ float ceil(float f);
 /// @note In case of a tie (i.e., +/- 0.5), rounds away from 0.
 float round(float f);
 
+/// @brief Determine if x is in [a..b]
+/// @param x Value to compare
+/// @param a Low end of range
+/// @param b High end of range
+int between(int x, int a, int b);
+
+/// @brief Determine if x is in [a..b]
+/// @param x Value to compare
+/// @param a Low end of range
+/// @param b High end of range
+int fbetween(float x, float a, float b);
 
 // -----------------------------------------------------------------------------
 //                             Function Definitions
@@ -153,4 +164,14 @@ float ceil(float f)
 float round(float f)
 {
     return IntToFloat(FloatToInt(f + (f < 0.0 ? -0.5 : 0.5)));
+}
+
+int between(int x, int a, int b)
+{
+    return ((x - a) * (x - b)) <= 0;
+}
+
+int fbetween(float x, float a, float b)
+{
+    return ((x - a) * (x - b)) <= 0.0;
 }


### PR DESCRIPTION
Discovered that `GetConstantName()` wasn't handling any existing whitespace between the constant value and the line-ending semi-colon.  Constants in nwscript sometimes have the white space and sometimes do not.  This modification accounts for both and properly returns the constant name for those constants that can be returned.