### PR TITLE
Fixes to `util_i_variables`

### DIFF
--- a/src/util_c_variables.nss
+++ b/src/util_c_variables.nss
@@ -89,3 +89,32 @@ string ObjectToDatabaseTag(object oSource, object oDatabase, string sVarName,
 {
     return sTag;
 }
+
+// -----------------------------------------------------------------------------
+//                          Debugging Messages
+// -----------------------------------------------------------------------------
+// This function is called when a debug message needs to be sent due to errors
+//  int the system.  Any debug system may be used through this conduit.  The
+//  sample code uses sm-util's util_i_debug.nss.
+// -----------------------------------------------------------------------------
+
+// These are generic constants and can be modified or deleted at anytime to
+//  better suit your debugging preferences.
+
+const int DEBUG_SEVERITY_NONE     = 0;
+const int DEBUG_SEVERITY_CRITICAL = 1;
+const int DEBUG_SEVERITY_ERROR    = 2;
+const int DEBUG_SEVERITY_WARNING  = 3;
+const int DEBUG_SEVERITY_NOTICE   = 4;
+const int DEBUG_SEVERITY_DEBUG    = 5;
+
+/// @brief Sends a debug message to the desired destination.
+/// @param sMessage The debug message.
+/// @param nSeverity DEBUG_SEVERITY_*.
+
+// #include "util_i_debug"
+
+void Variable_Debug(string sMessage, int nSeverity = DEBUG_SEVERITY_NOTICE)
+{
+    //Debug(sMessage, nSeverity);
+}


### PR DESCRIPTION
When trying to copy bewteen any database and object, I found that the system was storing values as json objects instead of sqlite or nwn primitive compatible values.  I modified the code to convert between json and primitive at the appropriate time.  Tested by copying variables between objects and databases and back again.

The only noted issue was the standard accuracy of floats, just like nwn always seems to deal with.

I also added a debug function to `util_c_variables` and removed `util_i_debug` from the primary to allow other to use their own debugging system, but left example code in for `util_i_debug` usage.

Finally, added local VectorToJson, JsonToVector, LocationToJson and JsonToLocation to remove dependence on `util_i_varlists`, but really because this utility is designed around persistence and the `LocationToJson` in `util_i_varlists` using an object id for the area, which will change on every module reload.  The local version `_LocationToJson` uses the area object tag to allow for persistence across module resets.