### PR TITLE
Add candidate utility `util_i_argstack`

### DIFF
--- a/src/util_c_unittest.nss
+++ b/src/util_c_unittest.nss
@@ -52,6 +52,11 @@ const int UNITTEST_PARAMETER_RECEIVED = COLOR_PINK;
 //  test failure.
 const string UNITTEST_FAILURE_SCRIPT = "";
 
+// This value determines whether test results are expanded.  Set to TRUE to force
+//  all test results to show expanded data.  Set to FALSE to show expanded data
+//  only on test failures.
+const int UNITTEST_ALWAYS_EXPAND = FALSE;
+
 // -----------------------------------------------------------------------------
 //                        Helper Constants and Functions
 // -----------------------------------------------------------------------------

--- a/src/util_i_argstack.nss
+++ b/src/util_i_argstack.nss
@@ -1,0 +1,385 @@
+
+/// ----------------------------------------------------------------------------
+/// @file   util_i_argstack.nss
+/// @author Ed Burke (tinygiant98) <af.hog.pilot@gmail.com>
+/// @brief  Functions for manipulating an argument stack.
+/// @details
+/// An argument stack provides a method for library functions to send values
+///     to other functions without being able to call them directly.  This allows
+///     library functions to abstract away the connection layer and frees the
+///     builder to design plug-and-play systems that don't break when unrelated
+///     systems are removed or replaced.
+///
+/// Stacks work on a last in - first out basis and are split by variable type.
+///     Popping a value will delete and return the last entered value of the
+///     specified type stack.  Other variable types will not be affected.
+///
+/// ```nwscript
+/// PushInt(30);
+/// PushInt(40);
+/// PushInt(50);
+/// PushString("test");
+///
+/// int nPop = PopInt();       // nPop = 50
+/// string sPop = PopString(); // sPop = "test";
+/// ```nwscript
+/// ----------------------------------------------------------------------------
+
+#include "util_i_varlists"
+
+const string ARGS_DEFAULT_STACK = "ARGS_DEFAULT_STACK";
+
+// -----------------------------------------------------------------------------
+//                              Function Prototypes
+// -----------------------------------------------------------------------------
+
+/// @brief Push as value onto the stack.
+/// @param nValue Value to add to stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Count of values on the stack.
+int PushInt(int nValue, string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Pop a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+int PopInt(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Peek a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+int PeekInt(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Retrieve the stack size.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns The number of values in the stack.
+int CountIntStack(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Push as value onto the stack.
+/// @param sValue Value to add to stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Count of values on the stack.
+int PushString(string sValue, string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Pop a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+string PopString(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Peek a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+string PeekString(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Retrieve the stack size.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns The number of values in the stack.
+int CountStringStack(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Push as value onto the stack.
+/// @param fValue Value to add to stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Count of values on the stack.
+int PushFloat(float fValue, string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Pop a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+float PopFloat(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Peek a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+float PeekFloat(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Retrieve the stack size.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns The number of values in the stack.
+int CountFloatStack(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Push as value onto the stack.
+/// @param oValue Value to add to stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Count of values on the stack.
+int PushObject(object oValue, string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Pop a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+object PopObject(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Peek a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+object PeekObject(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Retrieve the stack size.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns The number of values in the stack.
+int CountObjectStack(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Push as value onto the stack.
+/// @param lValue Value to add to stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.getlistfloat
+/// @returns Count of values on the stack.
+int PushLocation(location lValue, string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Pop a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+location PopLocation(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Peek a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+location PeekLocation(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Retrieve the stack size.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns The number of values in the stack.
+int CountLocationStack(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Push as value onto the stack.
+/// @param vValue Value to add to stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Count of values on the stack.
+int PushVector(vector vValue, string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Pop a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+vector PopVector(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Peek a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+vector PeekVector(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Retrieve the stack size.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns The number of values in the stack.
+int CountVectorStack(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Push as value onto the stack.
+/// @param jValue Value to add to stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Count of values on the stack.
+int PushJson(json jValue, string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Pop a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+json PopJson(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Peek a value from the stack.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns Most recent value pushed on the stack.
+json PeekJson(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Retrieve the stack size.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @returns The number of values in the stack.
+int CountJsonStack(string sListName = "", object oTarget = OBJECT_INVALID);
+
+/// @brief Clear all stack values.
+/// @param sListName [Optional] Name of stack.
+/// @param oTarget [Optional] Object stack will be saved to.
+/// @note Use this function to ensure all stack values are cleared.
+void ClearStacks(string sListName = "", object oTarget = OBJECT_INVALID);
+
+// -----------------------------------------------------------------------------
+//                              Function Definitions
+// -----------------------------------------------------------------------------
+
+string _GetListName(string s)
+{
+    return s == "" ? ARGS_DEFAULT_STACK : s;
+}
+
+object _GetTarget(object o)
+{
+    if (o == OBJECT_INVALID || GetIsObjectValid(o) == FALSE)
+        return GetModule();
+    return o;
+}
+
+int PushInt(int nValue, string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return InsertListInt(_GetTarget(oTarget), 0, nValue, _GetListName(sListName));
+}
+
+int PopInt(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return PopListInt(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+int PeekInt(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return GetListInt(_GetTarget(oTarget), 0, _GetListName(sListName));
+}
+
+int CountIntStack(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return CountIntList(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+int PushString(string sValue, string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return InsertListString(_GetTarget(oTarget), 0, sValue, _GetListName(sListName));
+}
+
+string PopString(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return PopListString(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+string PeekString(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return GetListString(_GetTarget(oTarget), 0, _GetListName(sListName));
+}
+
+int CountStringStack(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return CountStringList(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+int PushFloat(float fValue, string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return InsertListFloat(_GetTarget(oTarget), 0, fValue, _GetListName(sListName), FALSE);
+}
+
+float PopFloat(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return PopListFloat(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+float PeekFloat(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return GetListFloat(_GetTarget(oTarget), 0, _GetListName(sListName));
+}
+
+int CountFloatStack(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return CountFloatList(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+int PushObject(object oValue, string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return InsertListObject(_GetTarget(oTarget), 0, oValue, _GetListName(sListName));
+}
+
+object PopObject(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return PopListObject(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+object PeekObject(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return GetListObject(_GetTarget(oTarget), 0, _GetListName(sListName));
+}
+
+int CountObjectStack(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return CountObjectList(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+int PushLocation(location lValue, string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return InsertListLocation(_GetTarget(oTarget), 0, lValue, _GetListName(sListName));
+}
+
+location PopLocation(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return PopListLocation(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+location PeekLocation(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return GetListLocation(_GetTarget(oTarget), 0, _GetListName(sListName));
+}
+
+int CountLocationStack(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return CountLocationList(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+int PushVector(vector vValue, string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return InsertListVector(_GetTarget(oTarget), 0, vValue, _GetListName(sListName));
+}
+
+vector PopVector(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return PopListVector(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+vector PeekVector(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return GetListVector(_GetTarget(oTarget), 0, _GetListName(sListName));
+}
+
+int CountVectorStack(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return CountVectorList(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+int PushJson(json jValue, string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return InsertListJson(_GetTarget(oTarget), 0, jValue, _GetListName(sListName));
+}
+
+json PopJson(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return PopListJson(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+json PeekJson(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return GetListJson(_GetTarget(oTarget), 0, _GetListName(sListName));
+}
+
+int CountJsonStack(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    return CountJsonList(_GetTarget(oTarget), _GetListName(sListName));
+}
+
+void ClearStacks(string sListName = "", object oTarget = OBJECT_INVALID)
+{
+    sListName = _GetListName(sListName);
+    oTarget = _GetTarget(oTarget);
+
+    DeleteIntList(oTarget, sListName);
+    DeleteStringList(oTarget, sListName);
+    DeleteFloatList(oTarget, sListName);
+    DeleteObjectList(oTarget, sListName);
+    DeleteLocationList(oTarget, sListName);
+    DeleteVectorList(oTarget, sListName);
+    DeleteJsonList(oTarget, sListName);
+}

--- a/src/util_i_color.nss
+++ b/src/util_i_color.nss
@@ -344,21 +344,5 @@ string HSVColorString(string sString, struct HSV hsv)
 
 string UnColorString(string sString)
 {
-    sString = StringReplace(sString, "</c>", "");
-    int nOpen = FindSubString(sString, "<c");
-    int nClose = FindSubString(sString, ">", nOpen);
-    int nLength;
-    string sPrefix, sSuffix;
-
-    while (nOpen != -1 && nClose != -1)
-    {
-        nLength = GetStringLength(sString);
-        sPrefix = GetStringLeft(sString, nOpen);
-        sSuffix = GetStringRight(sString, nLength - nClose - 1);
-        sString = sPrefix + sSuffix;
-        nOpen = FindSubString(sString, "<c");
-        nClose = FindSubString(sString, ">", nOpen);
-    }
-
-    return sString;
+    return RegExpReplace("<c[\\S\\s]{3}>|<\\/c>", sString, "");
 }

--- a/src/util_i_lists.nss
+++ b/src/util_i_lists.nss
@@ -52,17 +52,10 @@ string JoinList(object oTarget, string sListName = "", int bAddUnique = FALSE, i
 
 json SplitList(object oTarget, string sList, string sListName = "", int bAddUnique = FALSE, int nListType = LIST_TYPE_STRING)
 {
-    json jList = JsonArray();
+    json jList = JSON_ARRAY;
 
     if (nListType == LIST_TYPE_STRING)
-    {
-        int n, nCount = CountList(sList);
-        for (n = 0; n < nCount; n++)
-        {
-            string sListItem = GetListItem(sList, n);
-            jList = JsonArrayInsert(jList, JsonString(TrimString(sListItem)));
-        }
-    }
+        jList = ListToJson(sList, TRUE);
     else
         jList = JsonParse("[" + sList + "]");
 
@@ -94,11 +87,7 @@ string JoinList(object oTarget, string sListName = "", int bAddUnique = FALSE, i
 
     string sList;
     if (nListType == LIST_TYPE_STRING)
-    {
-        int n, nCount = JsonGetLength(jList);
-        for (n = 0; n < nCount; n++)
-            sList = AddListItem(sList, JsonGetString(JsonArrayGet(jList, n)));
-    }
+        sList = JsonToList(jList);
     else
     {
         sList = JsonDump(jList);

--- a/src/util_i_strings.nss
+++ b/src/util_i_strings.nss
@@ -2,7 +2,7 @@
 /// @file   util_i_strings.nss
 /// @author Michael A. Sinclair (Squatting Monk) <squattingmonk@gmail.com>
 /// @author Ed Burke (tinygiant98) <af.hog.pilot@gmail.com>
-/// @brief  Functions for formatting times
+/// @brief  Functions for manipulating strings
 /// ----------------------------------------------------------------------------
 /// @details This file holds utility functions for manipulating strings.
 /// ----------------------------------------------------------------------------
@@ -323,23 +323,17 @@ int GetIsAlphaNumeric(string sString)
 
 string TrimStringLeft(string sString, string sRemove = " ")
 {
-    while (FindSubString(sRemove, GetStringLeft(sString, 1)) != -1)
-        sString = GetStringRight(sString, GetStringLength(sString) - 1);
-
-    return sString;
+    return RegExpReplace("^(?:" + sRemove + ")*", sString, "");
 }
 
 string TrimStringRight(string sString, string sRemove = " ")
 {
-    while (FindSubString(sRemove, GetStringRight(sString, 1)) != -1)
-        sString = GetStringLeft(sString, GetStringLength(sString) - 1);
-
-    return sString;
+    return RegExpReplace("(:?" + sRemove + ")*$", sString, "");
 }
 
 string TrimString(string sString, string sRemove = " ")
 {
-    return TrimStringRight(TrimStringLeft(sString, sRemove), sRemove);
+    return RegExpReplace("^(:?" + sRemove + ")*|(?:" + sRemove + ")*$", sString, "");
 }
 
 string FormatValues(json jArray, string sFormat)
@@ -374,7 +368,7 @@ string FormatFloat(float f, string sFormat)
     json jArray = JsonArray();
     int i, nCount = GetSubStringCount(sFormat, "%");
     for (i = 0; i < nCount; i++)
-        jArray = JsonArrayInsert(jArray, JsonFloat(f));
+        JsonArrayInsertInplace(jArray, JsonFloat(f));
     return FormatValues(jArray, sFormat);
 }
 
@@ -383,7 +377,7 @@ string FormatInt(int n, string sFormat)
     json jArray = JsonArray();
     int i, nCount = GetSubStringCount(sFormat, "%");
     for (i = 0; i < nCount; i++)
-        jArray = JsonArrayInsert(jArray, JsonInt(n));
+        JsonArrayInsertInplace(jArray, JsonInt(n));
     return FormatValues(jArray, sFormat);
 }
 
@@ -392,7 +386,7 @@ string FormatString(string s, string sFormat)
     json jArray = JsonArray();
     int i, nCount = GetSubStringCount(sFormat, "%");
     for (i = 0; i < nCount; i++)
-        jArray = JsonArrayInsert(jArray, JsonString(s));
+        JsonArrayInsertInplace(jArray, JsonString(s));
     return FormatValues(jArray, sFormat);
 }
 

--- a/src/util_i_targeting.nss
+++ b/src/util_i_targeting.nss
@@ -416,11 +416,6 @@ void _DeleteTargetingHookData(int nHookID)
 void _ExitTargetingMode(int nHookID)
 {
     struct TargetingHook th = GetTargetingHookDataByHookID(nHookID);
-
-    DeleteTargetingHook(nHookID);
-    DeleteLocalInt(th.oPC, TARGET_HOOK_ID);
-    DeleteLocalInt(th.oPC, TARGET_HOOK_BEHAVIOR);
-
     if (th.sScript != "")
     {
         Debug("Running post-targeting script " + th.sScript + " from Targeting Hook ID " +
@@ -430,6 +425,10 @@ void _ExitTargetingMode(int nHookID)
     else
         Debug("No post-targeting script specified for Targeting Hook ID " + IntToString(nHookID) + " " +
             "on " + GetName(th.oPC) + " with varname " + th.sVarName);
+
+    DeleteTargetingHook(nHookID);
+    DeleteLocalInt(th.oPC, TARGET_HOOK_ID);
+    DeleteLocalInt(th.oPC, TARGET_HOOK_BEHAVIOR);
 }
 
 // Reduces the number of targeting hooks remaining. When the remaining number is
@@ -664,7 +663,7 @@ int GetTargetingHookID(object oPC, string sVarName)
     string s =  "SELECT nHookID " +
                 "FROM targeting_hooks " +
                 "WHERE sUUID = @sUUID " +
-                    "AND sVarName =@sVarName;";
+                    "AND sVarName = @sVarName;";
 
     sqlquery q = _PrepareTargetingQuery(s);
     SqlBindString(q, "@sUUID", GetObjectUUID(oPC));

--- a/src/util_i_unittest.nss
+++ b/src/util_i_unittest.nss
@@ -5,50 +5,109 @@
 /// ----------------------------------------------------------------------------
 /// @details
 ///
+/// Variable Conventions:
+///
+/// Tests can be written in just about any format, however since tests tend to be
+///     repetitive, having a variable and formatting convention can make building
+///     multiple tests quick and easy.  Following are variable naming conventions
+///     and an example that showcases how to use them.
+///
+///     Variable Naming:
+///         ix - Function Input Variables
+///         ex - Expected Function Result Variables
+///         rx - Actual Function Result Variables
+///         bx - Boolean Test Result Variables
+///         tx - Timer Variables
+///
+///     Convenience Functions:
+///         _i : IntToString
+///         _f : FloatToString; Rounds to significant digits
+///         _b : Returns `True` or `False` (literals)
+///
+///         _q  : Returns string wrapped in single quotes
+///         _qq : Return string wrapped in souble quotes
+///         _p  : Retursn string wrapped in parenthesis
+///
+///     Timers:
+///         To start a timer:
+///             t1 = Timer();   : Sets timer variable `t1` to GetMicrosecondCounter()
+///
+///         To end a timer and save the results:
+///             t1 = Timer(t1); : Sets timer variable `t1` to GetMicrosecondCounter() - t1
+/// 
 /// The following example shows how to create a grouped assertion and display
 ///     only relevant results, assuming only assertion failures are of
-//      interest.
-    /*
-    string sVarName = "TEST";
-
-    // Conduct the unit testing and store the results
-    int a, b, c;
-
-    a = 751;
-    SetLocaInt(GetModule(), "TEST", a);
-    b = GetLocalInt(GetModule(), "TEST");
-    DeleteLocalInt(GetModule(), "TEST");
-    c = GetLocalInt(GetModule(), "TEST");
-
-    // Conduct the assertions to display the results
-    // Using a group assertion will provide for collapsed results to
-    //  prevent spamming the chat window. The AssertGroup() function
-    //  returns the result of the assertion, so it can be used to
-    //  allow/prevent the display of expanded results. If display
-    //  of the individual assertions is desired, remove the not (!) or
-    //  use DescribeGroupTest() to add a title without an assertion result.
-    if (!AssertGroup("[Set|Get|Delete]PlayerInt", a == b && c == 0))
-    {
-        // If the Group Assertion fails, the individual assertions that
-        //  make up the group assertion can be displayed. Like AssertGroup(),
-        //  Assert() returns the result of the assertion, so it can be used
-        //  to prevent displaying passing results when only failing results
-        //  are of interest
-        if (!Assert("SetPlayerInt", a == b))
-            AssertParameters(IntToString(a), IntToString(a), IntToString(b));
-
-        if (!Assert("GetPlayerInt", a == b))
-            AssertParameters(IntToString(a), IntToString(a), IntToString(b));
-
-        if (!Assert("DeletePlayerInt", c == 0))
-            AssertParameters(IntToString(a), IntToString(0), IntToString(c));
-    } ResetIndent();
-    */
-    // Note:  Use of ResetIndent() or another indentation function, such as
-    //  Outdent() may be required if moving to another group assertion.
-
+///     interest.  If you always want to see expanded results regardless of test
+///     outcome, set UNITTEST_ALWAYS_EXPAND to TRUE in `util_c_unittest`.
+///
+/// For example purposes only, this unit test sample code will run a unittest
+///     against following function, which will return -1, if n <= 0; 20 *n, if 0 < n <= 3;
+///     and 100, if n > 3;
+///
+/// ```nwscript
+/// int unittest_demo_ConvertValue(int n)
+/// {
+///     return n <= 0 ? -1 : n > 3 ? 100 : 20 * n;
+/// }
+/// ```
+///
+/// The following unit test will run against the function above for three test cases:
+///     - Out of bounds (low) -> n <= 0;
+///     - In bound -> 0 < n <= 3;
+///     - Out of bounds (high) -> n > 3;
+///
+/// ```nwscript
+/// int unittest_ConvertValue()
+/// {
+///     int i1, i2, i3;
+///     int e1, e2, e3;
+///     int r1, r2, r3;
+///     int b1, b2, b3, b;
+///     int t1, t2, t3, t;
+/// 
+///     // Setup the input values
+///     i1 = -10;
+///     i2 = 2;
+///     i3 = 12;
+/// 
+///     // Setup the expected return values 
+///     e1 = -1;
+///     e2 = 40;
+///     e3 = 100;
+/// 
+///     // Run the unit tests with timers
+///     t = Timer();
+///     t1 = Timer(); r1 = unittest_demo_ConvertValue(i1); t1 = Timer(t1);
+///     t2 = Timer(); r2 = unittest_demo_ConvertValue(i2); t2 = Timer(t2);
+///     t3 = Timer(); r3 = unittest_demo_ConvertValue(i3); t3 = Timer(t3);
+///     t = Timer(t);
+/// 
+///     // Populate the results
+///     b = (b1 = r1 == e1) &
+///         (b2 = r2 == e2) &
+///         (b3 = r3 == e3);
+/// 
+///     // Display the result
+///     if (!AssertGroup("ConvertValue()", b))
+///     {
+///         if (!Assert("Out of bounds (low)", b1))
+///             DescribeTestParameters(_i(i1), _i(e1), _i(r1));
+///         DescribeTestTime(t1);
+/// 
+///         if (!Assert("In bounds", b2))
+///             DescribeTestParameters(_i(i2), _i(e2), _i(r2));
+///         DescribeTestTime(t2);
+/// 
+///         if (!Assert("Out of bounds (high)", b3))
+///             DescribeTestParameters(_i(i3), _i(e3), _i(r3));
+///         DescribeTestTime(t3);
+///     } DescribeGroupTime(t); Outdent();
+/// }
+/// Note:  Use of ResetIndent() or another indentation function, such as
+/// Outdent(), may be required if moving to another group assertion.
 
 #include "util_c_unittest"
+#include "util_i_strings"
 
 // -----------------------------------------------------------------------------
 //                                   Constants
@@ -63,6 +122,15 @@ string TEST_DELIMITER = HexColorString(" | ", COLOR_WHITE);
 // -----------------------------------------------------------------------------
 //                              Function Prototypes
 // -----------------------------------------------------------------------------
+
+/// @brief Establishes or calculates a timer or elapsed value.
+/// @param t Previous timer value derived from this function.
+/// @note Calling this function without parameter `t` specified will
+///     return a starting value in microseconds.  When the code in
+///     question has been run, call this function again and pass
+///     the previously returned value as parameter `t` to calculate
+///     the total elapsed time for between calls to this function.
+int Timer(int t = 0);
 
 /// @brief Reset the indentation level used in displaying test results.
 /// @returns The indenation string used to pad test result output.
@@ -100,6 +168,16 @@ void DescribeTestGroup(string sDescription);
 ///     that parameter will not be output.
 void DescribeTestParameters(string sInput = "", string sExpected = "", string sReceived = "");
 
+/// @brief Display function timer result.
+/// @param nTime Function timer result, in microseconds.
+/// @note This function is intended to use output from GetMicrosecondCounter().
+void DescribeTestTime(int nTime);
+
+/// @brief Display function timer result.
+/// @param nTime Function timer result, in microseconds.
+/// @note This function is intended to use output from GetMicrosecondCounter().
+void DescribeGroupTime(int nTime);
+
 /// @brief Display the results of a unit test.
 /// @param sTest The name of the unit test.
 /// @param bAssertion The results of the unit test.
@@ -136,6 +214,19 @@ string _GetIndent(int bReset = FALSE)
 //                        Public Function Implementations
 // -----------------------------------------------------------------------------
 
+string _i(int n)     { return IntToString(n); }
+string _f(float f)   { return FormatFloat(f, "%!f"); }
+string _b(int b)     { return b ? "True" : "False"; }
+
+string _q(string s)  { return "'" + s + "'"; }
+string _qq(string s) { return "\"" + s + "\""; }
+string _p(string s)  { return "(" + s + ")"; }
+
+int Timer(int t = 0)
+{
+    return GetMicrosecondCounter() - t;
+}
+
 string ResetIndent()
 {
     DeleteLocalInt(GetModule(), TEST_INDENT);
@@ -149,7 +240,6 @@ string Indent(int bReset = FALSE)
 
     int nIndent = GetLocalInt(GetModule(), TEST_INDENT);
     SetLocalInt(GetModule(), TEST_INDENT, ++nIndent);
-
     return _GetIndent();
 }
 
@@ -157,7 +247,6 @@ string Outdent()
 {
     int nIndent = GetLocalInt(GetModule(), TEST_INDENT);
     SetLocalInt(GetModule(), TEST_INDENT, max(0, --nIndent));
-
     return _GetIndent();
 }
 
@@ -165,8 +254,7 @@ void DescribeTestSuite(string sDescription)
 {
     sDescription = HexColorString("Test Suite ", UNITTEST_TITLE_COLOR) +
         HexColorString(sDescription, UNITTEST_NAME_COLOR);
-
-    ResetIndent();
+    Indent(TRUE);
     HandleUnitTestOutput(sDescription);
 }
 
@@ -174,16 +262,40 @@ void DescribeTestGroup(string sDescription)
 {
     sDescription = HexColorString("Test Group ", UNITTEST_TITLE_COLOR) +
         HexColorString(sDescription, UNITTEST_NAME_COLOR);
-
     HandleUnitTestOutput(_GetIndent() + sDescription);
     Indent();
 }
 
 void DescribeTestParameters(string sInput, string sExpected, string sReceived)
 {
+    Indent();
     if (sInput != "")
     {
-        sInput = _GetIndent() + HexColorString("     Input: ", UNITTEST_PARAMETER_COLOR) +
+        json jInput = JsonParse(sInput);
+        if (jInput != JSON_NULL && JsonGetLength(jInput) > 0)
+        {
+            if (JsonGetType(jInput) == JSON_TYPE_ARRAY)
+            {
+                string s = "WITH atoms AS (SELECT atom FROM json_each(@json)) " +
+                           "SELECT group_concat(atom, ' | ') FROM atoms;";
+                sqlquery q = SqlPrepareQueryObject(GetModule(), s);
+                SqlBindJson(q, "@json", jInput);
+                sInput = SqlStep(q) ? SqlGetString(q, 0) : sInput;
+            }
+            else if (JsonGetType(jInput) == JSON_TYPE_OBJECT)
+            {
+                string s = "WITH kvps AS (SELECT key, value FROM json_each(@json)) " +
+                           "SELECT group_concat(key || ' = ' || (IFNULL(value, '\"\"\"\"')), ' | ') FROM kvps;";
+                sqlquery q = SqlPrepareQueryObject(GetModule(), s);
+                SqlBindJson(q, "@json", jInput);
+                sInput = SqlStep(q) ? SqlGetString(q, 0) : sInput;
+            }
+
+            sInput = RegExpReplace("(?:^|\\| )(.*?)(?= =)", sInput, HexToColor(COLOR_BLUE_STEEL) + "$&</c>");
+            sInput = RegExpReplace("\\||=", sInput, HexToColor(COLOR_WHITE) + "$&</c>");
+        }
+
+        sInput = _GetIndent() + HexColorString("Input: ", UNITTEST_PARAMETER_COLOR) +
             HexColorString(sInput, UNITTEST_PARAMETER_INPUT);
 
         HandleUnitTestOutput(sInput);
@@ -204,6 +316,33 @@ void DescribeTestParameters(string sInput, string sExpected, string sReceived)
 
         HandleUnitTestOutput(sReceived);
     }
+    Outdent();
+}
+
+void DescribeTestTime(int nTime)
+{
+    if (nTime <= 0)
+        return;
+
+    Indent();
+    string sTimer = _f(nTime / 1000000.0);
+    string sTime = _GetIndent() + HexColorString("Test Time: ", UNITTEST_PARAMETER_COLOR) +
+        HexColorString(sTimer + "s", UNITTEST_PARAMETER_INPUT);
+    Outdent();
+
+    HandleUnitTestOutput(sTime);
+}
+
+void DescribeGroupTime(int nTime)
+{
+    if (nTime <= 0)
+        return;
+
+    string sTimer = _f(nTime / 1000000.0);
+    string sTime = _GetIndent() + HexColorString("Group Time: ", UNITTEST_PARAMETER_COLOR) +
+        HexColorString(sTimer + "s", UNITTEST_PARAMETER_INPUT);
+
+    HandleUnitTestOutput(sTime);
 }
 
 int Assert(string sTest, int bAssertion)
@@ -216,7 +355,7 @@ int Assert(string sTest, int bAssertion)
     if (!bAssertion)
         HandleUnitTestFailure(sTest);
 
-    return bAssertion;
+    return UNITTEST_ALWAYS_EXPAND ? FALSE : bAssertion;
 }
 
 int AssertGroup(string sGroup, int bAssertion)
@@ -230,5 +369,5 @@ int AssertGroup(string sGroup, int bAssertion)
     if (!bAssertion)
         HandleUnitTestFailure(sGroup);
 
-    return bAssertion;
+    return UNITTEST_ALWAYS_EXPAND ? FALSE : bAssertion;
 }


### PR DESCRIPTION
Add `util_i_argstack` to allow more robust passage of variables between functions when functions are not inclusive to the current script.  This primarily targets the library system and is similar to, but a much expanded version of, script parameters.

Each type includes a function to: `Push`, `Pop`, `Peek` and `Count` the type's argument stack.

This should not be incorporated until the previous PR (.36 updates) is incorporated because it relies on new functions in `util_i_varlists`