### PR TITLE
add player object dispatch list to util_i_debug

### DIFF
--- a/src/util_i_debug.nss
+++ b/src/util_i_debug.nss
@@ -15,6 +15,7 @@ const string DEBUG_LEVEL    = "DEBUG_LEVEL";
 const string DEBUG_LOG      = "DEBUG_LOG";
 const string DEBUG_OVERRIDE = "DEBUG_OVERRIDE";
 const string DEBUG_PREFIX   = "DEBUG_PREFIX";
+const string DEBUG_DISPATCH = "DEBUG_DISPATCH";
 
 // Debug levels
 const int DEBUG_LEVEL_NONE     = 0; ///< No debug level set
@@ -29,10 +30,12 @@ const int DEBUG_LOG_NONE = 0x0; ///< Do not log debug messages
 const int DEBUG_LOG_FILE = 0x1; ///< Send debug messages to the log file
 const int DEBUG_LOG_DM   = 0x2; ///< Send debug messages to online DMs
 const int DEBUG_LOG_PC   = 0x4; ///< Send debug messages to the first PC
-const int DEBUG_LOG_ALL  = 0xf; ///< Send messages to the log file, DMs, and first PC
+const int DEBUG_LOG_LIST = 0x8; ///< Send debug messages to the dispatch list
+const int DEBUG_LOG_ALL  = 0xf; ///< Send messages to the log file, DMs, and first PC or dispatch list
 
-#include "util_i_color"
 #include "util_c_debug"
+#include "util_i_color"
+#include "util_i_varlists"
 
 // -----------------------------------------------------------------------------
 //                              Function Prototypes
@@ -92,6 +95,16 @@ int GetDebugLogging();
 /// @brief Set the enabled debug logging destinations.
 /// @param nEnabled A bitmask of `DEBUG_LOG_*` destinations to enable.
 void SetDebugLogging(int nEnabled);
+
+/// @brief Add a player object to the debug message dispatch list.  Player
+///     objects on the dispatch list will receive debug messages if the
+///     module's DEBUG_LOG_LEVEL includes DEBUG_LOG_LIST.
+/// @param oPC Player object to add.
+void AddDebugLoggingPC(object oPC);
+
+/// @brief Remove a player object from the debug dispatch list.
+/// @param oPC Player object to remove.
+void RemoveDebugLoggingPC(object oPC);
 
 /// @brief Return whether debug messages of a given level will be logged on a
 ///     target. Useful for avoiding spending cycles computing extra debug
@@ -230,6 +243,17 @@ void SetDebugLogging(int nEnabled)
     SetLocalInt(GetModule(), DEBUG_LOG, nEnabled);
 }
 
+void AddDebugLoggingPC(object oPC)
+{
+    if (GetIsPC(oPC))
+        AddListObject(GetModule(), oPC, DEBUG_DISPATCH, TRUE);
+}
+
+void RemoveDebugLoggingPC(object oPC)
+{
+    RemoveListObject(GetModule(), oPC, DEBUG_DISPATCH);
+}
+
 int IsDebugging(int nLevel, object oTarget = OBJECT_SELF)
 {
     return (nLevel <= GetDebugLevel(oTarget));
@@ -265,6 +289,17 @@ void Debug(string sMessage, int nLevel = DEBUG_LEVEL_DEBUG, object oTarget = OBJ
 
         if (nLogging & DEBUG_LOG_PC)
             SendMessageToPC(GetFirstPC(), sMessage);
+
+        if (nLogging & DEBUG_LOG_LIST)
+        {
+            json jDispatchList = GetObjectList(GetModule(), DEBUG_DISPATCH);
+            int n; for (n; n < JsonGetLength(jDispatchList); n++)
+            {
+                object oPC = GetListObject(GetModule(), n, DEBUG_DISPATCH);
+                if (GetIsPC(oPC) && !((nLogging & DEBUG_LOG_PC) && oPC == GetFirstPC()))
+                    SendMessageToPC(oPC, sMessage);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Been interested in adding dispatch list-like capability for logging for a long time.  This would allow debug messages to flow to specified pc objects.  The benefit of this is allowing debug messaging while a module is running with multiple players logged in, while also knowing/controlling where those messages go.  

Issues:
- I don't really like the names of the functions, but they make sense with other similar functions.  Got any better ideas?

This was inspired by @StefanoND and a different methodology to #38.